### PR TITLE
Unmark "/* ... */" as display-only

### DIFF
--- a/syntax/asl.vim
+++ b/syntax/asl.vim
@@ -20,7 +20,7 @@ syn region  aslBlock            start="{" end="}" transparent fold
 syn keyword aslTodo             contained TODO FIXME XXX NOTE
 
 syn region  aslComment          display start="//" skip="\\$" end="$" keepend contains=aslTodo
-syn region  aslComment          display start="/\*" end="\*\/" contains=aslTodo
+syn region  aslComment          start="/\*" end="\*\/" contains=aslTodo
 
 syn region  aslString           start=/"/ skip=/\\"/ end=/"/
 


### PR DESCRIPTION
Modern versions of iasl also include the ASCII representation of Buffers.
This might result in comments like `/* } */` which break syntax
highlighting and `fdm=syntax`. Remove the optimization in favor of more
usable folding.
